### PR TITLE
 changes to support oracle cloud infra (oci) storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ target/
 .gradle/
 gradle
 .DS_Store
+
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
 		<dependency>
 			<groupId>org.sunbird</groupId>
 			<artifactId>cloud-store-sdk_2.12</artifactId>
-			<version>1.4.3</version>
+			<version>1.4.6</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.inject</groupId>


### PR DESCRIPTION


upgraded the cloud-store-sdk version to 1.4.6 which supports s3 compliant object storage
